### PR TITLE
Enabling optional config file based on $XDG_CONFIG_HOME, if defined.

### DIFF
--- a/config.c
+++ b/config.c
@@ -855,7 +855,7 @@ void set_pbcopy(int linenr, char *cmd, char *par)
 
 void set_map_delete_as_backspace(int linenr, char *cmd, char *par)
 {
-	map_delete_as_backspace = config_yes_no(par);	
+	map_delete_as_backspace = config_yes_no(par);
 }
 
 void set_searchhistory_file(int linenr, char *cmd, char *par)
@@ -1255,15 +1255,18 @@ void load_configfile_wrapper(char *config_file)
 	{
 		int path_max = find_path_max();
 		char *path = mymalloc(path_max + 1);
+		char *xdg_config = getenv("XDG_CONFIG_HOME");
 		char *home = getenv("HOME");
 		struct passwd *pp = getuserinfo();
 
-		if (home)
+		if (xdg_config)
+			snprintf(path, path_max, "%s/multitail/config", xdg_config);
+		else if (home)
 			snprintf(path, path_max, "%s/.multitailrc", home);
 		else if (pp)
 			snprintf(path, path_max, "%s/.multitailrc", pp -> pw_dir);
 
-		if (pp || home)
+		if (xdg_config || home || pp)
 			do_load_config(-1, NULL, path);
 
 		myfree(path);

--- a/multitail.1
+++ b/multitail.1
@@ -342,6 +342,29 @@ Same as previous example. This example will store all logged entries in a buffer
 .BI "b"
  ').
 
+.SH FILES
+.TP
+.B "${XDG_CONFIG_HOME}/multitail/config"
+If
+.BI "${XDG_CONFIG_HOME}"
+is defined.
+.TP
+.B "${HOME}/.multitailrc"
+If
+.BI "${HOME}"
+is defined.
+.TP
+.B "~/.multitailrc"
+When either
+.BI "${XDG_CONFIG_HOME}"
+nor
+.BI "${HOME}"
+is defined, which will use
+.BI "(struct passwd*)pp->pw_dir"
+from the
+.BI "pwd.h"
+standard header.
+
 .SH BUGS
 As this program grew larger and larger over the time with new functionality sometimes added ad-hoc, some bugs may have been introduced. Please notify folkert@vanheusden.com if you find any.
 .PP
@@ -355,6 +378,6 @@ version 5.3 might help in that case.
 .SH NOTES
 This page describes
 .B MultiTail
-as found in the multitail-4.3.1 package; other versions may differ slightly.
+as found in the installed multitail package; other versions may differ slightly.
 Mail corrections and additions to folkert@vanheusden.com.
 Report bugs in the program to folkert@vanheusden.com.


### PR DESCRIPTION
Adding the ability for multitail to optionally use a config file based on the conventions of the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

The implementation on this MR should ignore the `${XDG_CONFIG_HOME}` environment variable if users do not define it.  Falling back to the original config file searching implementation.  However, if `${XDG_CONFIG_HOME}` is defined then multitail will search for the config under `${XDG_CONFIG_HOME}/multitail/config` which is the typical location for app specific config files when following the XDG Base Dir Spec.

Also included manpage updates.