### PR TITLE
Used LICENSE file as license.txt (license.txt is missing), and also f…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,11 +147,11 @@ install(FILES multitail.conf DESTINATION etc RENAME multitail.conf.new)
 install(FILES multitail.1 DESTINATION share/man/man1)
 # install doc files
 install(FILES manual.html DESTINATION share/doc/multitail-${VERSION})
-install(FILES license.txt DESTINATION share/doc/multitail-${VERSION})
+install(FILES LICENSE DESTINATION share/doc/multitail-${VERSION})
 install(FILES readme.txt DESTINATION share/doc/multitail-${VERSION})
 install(FILES thanks.txt DESTINATION share/doc/multitail-${VERSION})
 # cp conversion-scripts/* etc/multitail/
-install(DIRECTORY conversion-scripts DESTINATION ect/multitail)
+install(DIRECTORY conversion-scripts DESTINATION etc/multitail)
 
 
 if(USE_CPPCHECK)


### PR DESCRIPTION
…ixed ect-typo

I created a Yocto recipe for multitail, and during the quality control I stumpled accross:

1. license.txt is missing. I replaced that with LICENSE (apache 2.0) as my best intends
2. some files are gonna installed to ect/multitail. I suspect this is just a typo

Greetings and thanks for that awesome project!