### PR TITLE
Fix function definitions for clang16 and LTO

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -19,7 +19,7 @@ extern int n_pars_per_file;
 extern char mail;
 extern int check_for_mail;
 extern char tab_width;
-extern time_t mt_started;
+extern dtime_t mt_started;
 extern int *vertical_split;
 extern int *n_win_per_col;
 extern proginfo *terminal_index;

--- a/misc.c
+++ b/misc.c
@@ -477,7 +477,7 @@ void heartbeat(void)
 	mydoupdate();
 }
 
-void do_check_for_mail()
+void do_check_for_mail(dtime_t time)
 {
 	if (check_for_mail > 0 && mail_spool_file != NULL)
 	{

--- a/misc.h
+++ b/misc.h
@@ -1,5 +1,7 @@
+#import "mt.h"
+
 void info(void);
 void statistics_menu(void);
 void heartbeat(void);
-void do_check_for_mail();
+void do_check_for_mail(dtime_t time);
 void store_statistics(proginfo *cur, dtime_t now);

--- a/selbox.h
+++ b/selbox.h
@@ -1,4 +1,6 @@
-int selection_box(void **list, char *needs_mark, int nlines, char type, int what_help, char *heading);
+#include "mt.h"
+
+int selection_box(void **list, char *needs_mark, int nlines, selbox_type_t type, int what_help, char *heading);
 int select_window(int what_help, char *heading);
 proginfo * select_subwindow(int f_index, int what_help, char *heading);
 char * select_file(char *input, int what_help);


### PR DESCRIPTION
Hi,

Clang16 will not support implicit function declarations and implicit int and all the old C goodness by default. 
Therefore I wrote a patch for multitail 7.0.0 that fixes those problems. See: https://bugs.gentoo.org/874102

While at it I also fixed two function redefines that LTO does not like. See:  https://bugs.gentoo.org/855017