### PR TITLE
rectify mt_started definition in globals.c instead of globals.h

### DIFF
--- a/globals.c
+++ b/globals.c
@@ -81,7 +81,7 @@ double heartbeat_t = 0.0;
 off64_t msf_prev_size = 0;
 
 dtime_t msf_last_check = 0;
-dtime_t mt_started;
+time_t mt_started;
 
 pid_t children_list[MAX_N_SPAWNED_PROCESSES];
 pid_t tail_proc = 0;	/* process used by checker-proc */

--- a/globals.h
+++ b/globals.h
@@ -19,7 +19,7 @@ extern int n_pars_per_file;
 extern char mail;
 extern int check_for_mail;
 extern char tab_width;
-extern dtime_t mt_started;
+extern time_t mt_started;
 extern int *vertical_split;
 extern int *n_win_per_col;
 extern proginfo *terminal_index;


### PR DESCRIPTION
I think what I did there in #10 was wrong, because `time()` in `mt.c` (from `time.h`) [1]  expects `time_t`. Since `mt.c` imports `globals.h` it will import the wrong `dtime_t` from there, which results in a wrong pointer conversion. 

[1]  https://github.com/folkertvanheusden/multitail/blob/2afd0230499bc98b569d70800d46a213d4e1501c/mt.c#L2773

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>