### PR TITLE
Add color scheme cisco_ios

### DIFF
--- a/multitail.conf
+++ b/multitail.conf
@@ -1102,6 +1102,42 @@ cs_re_s:magenta:\:("\w*")
 cs_re_s:magenta:\:(\w*)
 cs_re_s:magenta:\:(".*")
 
+# Cisco IOS and IOS-XE
+colorscheme:cisco_ios
+# IP address and port
+cs_re:yellow,,bold:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}
+cs_re_s:yellow:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\(([0-9]*?)\)
+cs_re_s:yellow:localport\: ([0-9]*?)
+# interfaces
+cs_re:magenta:\s(\w?+Ethernet|GigE|Fa|Gi|Te|Twe|Fo|Fi|Hu|TH)
+cs_re_s:magenta,,bold:(Ethernet|GigE|Fa|Gi|Te|Twe|Fo|Fi|Hu|TH)([0-9]+/[0-9]+(/[0-9]+|))
+cs_re:green,,bold:\b(up|on)\b
+# User
+cs_re_s:magenta,,bold:User (\w+?)
+cs_re_s:magenta,,bold:user: (\w+?)
+# log levels
+cs_re:black,red:%\S*-0-\S*
+cs_re:black,red:%\S*-1-\S*
+cs_re:red:%\S*-2-\S*
+cs_re:red:%\S*-3-\S*
+cs_re:yellow:%\S*-4-\S*
+cs_re:yellow:%\S*-5-\S*
+cs_re:green:%\S*-6-\S*
+cs_re:black,white:%\S*-7-\S*
+# access lists
+cs_re_s:,,bold: list ([0-9]+)
+cs_re_s:blue,,bold: list [0-9]+ denied ([a-z0-9]*+).
+cs_re_s:blue,,bold: list [0-9]+ permitted ([a-z0-9]*+).
+cs_re:green,,bold:\bpermitted\b
+cs_re:red,,bold:\bdenied\b
+# misc
+cs_re:red,,bold:\b(down|off)\b
+cs_re_s:,,bold:[Pp]ower\ [Ss]upply\ ([0-9])
+cs_re:red,,bold:\bfaulty\b
+cs_re:red,,bold:error
+cs_re:red,,bold:high alarm
+cs_re:yellow,,bold:low alarm
+
 #
 # colorscript: colorscripts are external scripts that decide what colors to use
 #              for input they receive the line that needs colors


### PR DESCRIPTION
I rebased the branch as requested in https://github.com/folkertvanheusden/multitail/pull/25.

Original Message:
I created a color scheme for Cisco IOS (and IOS-XE) logs.

It looks like this:

![image](https://github.com/folkertvanheusden/multitail/assets/1270359/6b3e00d6-2ac2-4022-a255-2ff4e1f05f7a)
