### PR TITLE
Add color scheme cisco_asa

### DIFF
--- a/multitail.conf
+++ b/multitail.conf
@@ -1139,8 +1139,8 @@ cs_re:red,,bold:high alarm
 cs_re:yellow,,bold:low alarm
 
 # Cisco ASA
-# This colorscheme should be used upon cisco_ios
-# and is mainly for VPN logs
+# This and is mainly for VPN logs.
+# The colorscheme cisco_ios should be used after this one.
 colorscheme:cisco_asa
 # User
 cs_re_s:magenta,,bold:User <(\w+?)>
@@ -1149,11 +1149,16 @@ cs_re_s:magenta,,bold:User=(\w+?)
 cs_re_s:magenta,,bold:Username = (\w+?)
 cs_re_s:magenta,,bold:LOCAL\\(\w+?)
 # GroupPolicy
-cs_re_s:cyan,,bold: Group <(\w+?)>
-cs_re_s:cyan,,bold: Group = (\w+?)
-cs_re_s:cyan,,bold:GroupPolicy <(\w+?)>
+cs_re_s:blue,,bold: Group <(\S+?)>
+cs_re_s:blue,,bold: Group = (\S+?)
+cs_re_s:blue,,bold:GroupPolicy <(\S+?)>
 # TunnelGroup
-cs_re_s:blue,,bold:TunnelGroup <(\w+?)>
+cs_re_s:cyan,,bold:TunnelGroup <(\S+?)>
+# Assigned IP
+cs_re_s:green,,bold:IPv4 Address <([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})>
+cs_re_s:green,,bold: Assigned IP=([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})
+scheme:syslog,cisco_asa,cisco_ios:/data/log-adm/_vpn/
+scheme:syslog,cisco_asa,cisco_ios:/data/log-adm/local1/
 
 #
 # colorscript: colorscripts are external scripts that decide what colors to use

--- a/multitail.conf
+++ b/multitail.conf
@@ -1138,6 +1138,23 @@ cs_re:red,,bold:error
 cs_re:red,,bold:high alarm
 cs_re:yellow,,bold:low alarm
 
+# Cisco ASA
+# This colorscheme should be used upon cisco_ios
+# and is mainly for VPN logs
+colorscheme:cisco_asa
+# User
+cs_re_s:magenta,,bold:User <(\w+?)>
+cs_re_s:magenta,,bold:Username: (\w+?)
+cs_re_s:magenta,,bold:User=(\w+?)
+cs_re_s:magenta,,bold:Username = (\w+?)
+cs_re_s:magenta,,bold:LOCAL\\(\w+?)
+# GroupPolicy
+cs_re_s:cyan,,bold: Group <(\w+?)>
+cs_re_s:cyan,,bold: Group = (\w+?)
+cs_re_s:cyan,,bold:GroupPolicy <(\w+?)>
+# TunnelGroup
+cs_re_s:blue,,bold:TunnelGroup <(\w+?)>
+
 #
 # colorscript: colorscripts are external scripts that decide what colors to use
 #              for input they receive the line that needs colors

--- a/multitail.conf
+++ b/multitail.conf
@@ -1157,8 +1157,6 @@ cs_re_s:cyan,,bold:TunnelGroup <(\S+?)>
 # Assigned IP
 cs_re_s:green,,bold:IPv4 Address <([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})>
 cs_re_s:green,,bold: Assigned IP=([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})
-scheme:syslog,cisco_asa,cisco_ios:/data/log-adm/_vpn/
-scheme:syslog,cisco_asa,cisco_ios:/data/log-adm/local1/
 
 #
 # colorscript: colorscripts are external scripts that decide what colors to use

--- a/multitail.conf
+++ b/multitail.conf
@@ -1102,6 +1102,42 @@ cs_re_s:magenta:\:("\w*")
 cs_re_s:magenta:\:(\w*)
 cs_re_s:magenta:\:(".*")
 
+# Cisco IOS and IOS-XE
+colorscheme:cisco_ios
+# IP address and port
+cs_re:yellow,,bold:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}
+cs_re_s:yellow:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\(([0-9]*?)\)
+cs_re_s:yellow:localport\: ([0-9]*?)
+# interfaces
+cs_re:magenta:\s(\w?+Ethernet|GigE|Fa|Gi|Te|Twe|Fo|Fi|Hu|TH)
+cs_re_s:magenta,,bold:(Ethernet|GigE|Fa|Gi|Te|Twe|Fo|Fi|Hu|TH)([0-9]+/[0-9]+(/[0-9]+|))
+cs_re:green,,bold:\b(up|on)\b
+# User
+cs_re_s:magenta,,bold:User (\w+?)
+cs_re_s:magenta,,bold:user: (\w+?)
+# log levels
+cs_re:black,red:%\S*-0-\S*
+cs_re:black,red:%\S*-1-\S*
+cs_re:red:%\S*-2-\S*
+cs_re:red:%\S*-3-\S*
+cs_re:yellow:%\S*-4-\S*
+cs_re:yellow:%\S*-5-\S*
+cs_re:green:%\S*-6-\S*
+cs_re:black,white:%\S*-7-\S*
+# access lists
+cs_re_s:,,bold: list ([0-9]+)
+cs_re_s:blue,,bold: list [0-9]+ denied ([a-z0-9]*+).
+cs_re_s:blue,,bold: list [0-9]+ permitted ([a-z0-9]*+).
+cs_re:green,,bold:\bpermitted\b
+cs_re:red,,bold:\bdenied\b
+# misc
+cs_re:red,,bold:\b(down|off)\b
+cs_re_s:,,bold:[Pp]ower\ [Ss]upply\ ([0-9])
+cs_re:red,,bold:\bfaulty\b
+cs_re:red,,bold:error
+cs_re:red,,bold:high alarm
+cs_re:yellow,,bold:low alarm
+
 #
 # colorscript: colorscripts are external scripts that decide what colors to use
 #              for input they receive the line that needs colors


### PR DESCRIPTION
This colorscheme should be used upon cisco_ios and is mainly for VPN logs.