### PR TITLE
Update doc install [Cmake]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ install(FILES multitail.1 DESTINATION share/man/man1)
 # install doc files
 install(FILES manual.html DESTINATION share/doc/multitail-${VERSION})
 install(FILES LICENSE DESTINATION share/doc/multitail-${VERSION})
-install(FILES readme.txt DESTINATION share/doc/multitail-${VERSION})
+install(FILES README.md DESTINATION share/doc/multitail-${VERSION})
 install(FILES thanks.txt DESTINATION share/doc/multitail-${VERSION})
 # cp conversion-scripts/* etc/multitail/
 install(DIRECTORY conversion-scripts DESTINATION etc/multitail)


### PR DESCRIPTION
Update install instructions to pick up on new doc name.

`readme.txt` was renamed to `README.md` in 437ab1262a658887e5da7fa60a394956fffd2462 (2023-11-16)