### PR TITLE
Fix HTTP status codes colours in the "apache" scheme

### DIFF
--- a/help.c
+++ b/help.c
@@ -466,7 +466,7 @@ char *help_window_closed[] = {
 char *help_write_script[] = {
 		"This function writes a script to disk which will",
 		"start MultiTail in the same state it now is. This",
-		"is usefull in case you did a lot of configuring",
+		"is useful in case you did a lot of configuring",
 		"with the menu-interface, you then don't have to",
 		"find out what commandline switches to set.",
 		"Here you have to enter the filename for the script",
@@ -1405,7 +1405,7 @@ void usage(void)
 	format_help("-Cs", NULL, "colorize all following files with syslog-scheme");
 	format_help("-C", NULL, "colorize all following files");
 	format_help("-Cf/-cf field delimiter", NULL, "colorize next/all file(s) depending on the given field number. fields are delimited with the given field-delimiter");
-	format_help("-ci color", NULL, "use 'color' (red, green, etc), usefull when merging multiple inputs");
+	format_help("-ci color", NULL, "use 'color' (red, green, etc), useful when merging multiple inputs");
 	format_help("-c-", NULL, "do NOT colorize the following file");
 	format_help("-C-", NULL, "do NOT colorize the following files");
 	format_help("-cT term", NULL, "interpret terminal-codes from file/command (for terminal type 'term')");

--- a/manual.html
+++ b/manual.html
@@ -141,7 +141,7 @@ parameter it needs the name of a colorscheme. The colorschemes are read
 from multitail.conf. In multitail.conf you set by entering regular
 expressions what color to use for what "patterns". By default, MultiTail
 looks for multitail.conf in the current directory and in the /etc directory.
-With the '-z' parameter you can explicitly define what file it should use.<BR>
+With the '-F' parameter you can explicitly define what file it should use.<BR>
 An example:
 <PRE>
 colorscheme:postfix

--- a/manual.html
+++ b/manual.html
@@ -86,7 +86,7 @@ a reallife example:
 multitail /var/log/apache/access.log -I /var/log/apache/error.log
 </PRE>
 These two examples will merge the output of the given files into one
-window. This can be usefull with, for example, the files given in the
+window. This can be useful with, for example, the files given in the
 second example: with this example you see what happend just before an
 error appeared in the Apache errorlog.
 

--- a/multitail.1
+++ b/multitail.1
@@ -188,7 +188,7 @@ Show all following files in color depending on field selected with field_index. 
 Show the next file in color depending on field selected with field_index. Fields are delimited by the defined delimiter.
 .TP
 .B "\-ci color"
-Use a specific color. Usefull when merging multiple outputs.
+Use a specific color. Useful when merging multiple outputs.
 .TP
 .B "\-cT terminalmode"
 Interpret terminal codes. Only ANSI supported at this time.
@@ -281,7 +281,7 @@ When multiple files are merged an multitail switches between two windows, print 
 Do NOT print the markerline when the file changes (overrides the configfile).
 .TP
 .B "\--label text"
-Put "text" in front of each line. Usefull when merging multiple files and/or commands.
+Put "text" in front of each line. Useful when merging multiple files and/or commands.
 .TP
 .B "\--retry
 Keep trying to open the following file if it is inaccessible.

--- a/multitail.conf
+++ b/multitail.conf
@@ -229,9 +229,9 @@ cs_re:green:\]
 #
 # apache
 colorscheme:apache:default Apache logging (webserver)
-cs_re:yellow:"[ ]1[0-9][0-9][ ]
-cs_re:green:"[ ][2-3][0-9][0-9][ ]
-cs_re:red:"[ ][4-5][0-9][0-9][ ]
+cs_re_s:yellow:"[ ](1[0-9][0-9])[ ]
+cs_re_s:green:"[ ]([2-3][0-9][0-9])[ ]
+cs_re_s:red:"[ ]([4-5][0-9][0-9])[ ]
 cs_re:cyan::
 cs_re:green:\[
 cs_re:green:\]


### PR DESCRIPTION
These changes fix #34. Example of the output after the changes:

![Screenshot_2024-06-18_01-46-36](https://github.com/folkertvanheusden/multitail/assets/900115/d4bac843-7180-42a4-bfc1-aea2ed19a69d)
