### PR TITLE
fix implicit function declaration for waddnwstr in linux

### DIFF
--- a/mt.c
+++ b/mt.c
@@ -707,8 +707,6 @@ void do_color_print(proginfo *cur, char *use_string, int prt_start, int prt_end,
 		if (!is_control_or_extended_ascii)
 		{
 #if defined(UTF8_SUPPORT) && defined(NCURSES_WIDECHAR)
-// FIXME warning: implicit declaration of function ‘waddnwstr’ is invalid in C99  [-Wimplicit-function-declaration]
-// see /usr/include/ncurses.h
 			waddnwstr(win -> win, &wcur, 1);
 #else
 			wprintw(win -> win, "%c", wcur);

--- a/mt.h
+++ b/mt.h
@@ -60,10 +60,10 @@ typedef enum { SCHEME_TYPE_EDIT = 0, SCHEME_TYPE_FILTER } filter_edit_scheme_t;
 #endif
 
 #if defined(UTF8_SUPPORT) && !defined(__APPLE__)
-        #if defined(__FreeBSD__) || defined (__linux__)
+        #if defined(__FreeBSD__)
                 #include <panel.h>
                 #include <curses.h>
-        #else
+        #else /* if defined (__linux__) */
                 #include <ncursesw/panel.h>
                 #include <ncursesw/ncurses.h>
         #endif


### PR DESCRIPTION
I'm not a C developer, but it seems like the wrong curses header file is included