### PR TITLE
Replace deprecated `gethostbyaddr()` with `getnameinfo()`

### DIFF
--- a/cv.c
+++ b/cv.c
@@ -108,15 +108,20 @@ char *do_convert(char *what, int what_len, int type, script *pscript)
 			{
 				if (resolv_ip_addresses)
 				{
-					struct hostent *ht;
-					in_addr_t addr = inet_addr(what);
-					if ((int)addr == -1)
+					struct sockaddr_in sa;
+					char host[NI_MAXHOST];
+
+					memset(&sa, 0, sizeof(sa));
+					sa.sin_family = AF_INET;
+
+					if (inet_pton(AF_INET, what, &sa.sin_addr) != 1)
 						return mystrdup(what);
 
-					if ((ht = gethostbyaddr((char *)&addr, sizeof(addr), AF_INET)) == NULL)
+					if (getnameinfo((struct sockaddr *)&sa, sizeof(sa),
+							host, sizeof(host), NULL, 0, NI_NAMEREQD) != 0)
 						return mystrdup(what);
 
-					return mystrdup(ht -> h_name);
+					return mystrdup(host);
 				}
 
 				return mystrdup(what);

--- a/mt.c
+++ b/mt.c
@@ -3336,6 +3336,7 @@ int recv_from_fd(int fd, char **buffer, int new_data_offset, int read_size)
 	socklen_t ssa_len = sizeof(sa);
 	char *recv_buffer = mymalloc(read_size + 1);
 	char time_buffer[TIMESTAMP_EXTEND_BUFFER];
+	char resolved_host[NI_MAXHOST];
 	char *host = "";
 	char *facility = "";
 	char *severity = "";
@@ -3349,11 +3350,9 @@ int recv_from_fd(int fd, char **buffer, int new_data_offset, int read_size)
 
 	if (resolv_ip_addresses == MY_TRUE)
 	{
-		struct sockaddr_in *sai = (struct sockaddr_in *)&sa;
-		struct hostent *he = gethostbyaddr(&(sai -> sin_addr.s_addr), sizeof(sai -> sin_addr.s_addr), AF_INET);
-
-		if (he != NULL && he -> h_name != NULL)
-			host = he -> h_name;
+		if (getnameinfo(&sa, ssa_len, resolved_host, sizeof(resolved_host),
+		                NULL, 0, NI_NAMEREQD) == 0)
+			host = resolved_host;
 		else
 			host = "?";
 	}


### PR DESCRIPTION
The `gethostbyaddr()` function is deprecated (POSIX.1-2008) and has several issues:
- Not thread-safe (uses static internal buffer)
- Not IPv6 ready (only works with `AF_INET`)

Replaced with `getnameinfo()` in:
- cv.c: CONVTYPE_IP4TOHOST conversion
- mt.c: syslog sender IP resolution

Note: While `getnameinfo()` supports IPv6, the current implementation still only handles IPv4 addresses (matching the original functionality). Full IPv6 support would require additional changes.

This resolves rpmlint warnings about deprecated network functions.

Fixes #12