### PR TITLE
Centralize _LARGEFILE64_SOURCE definition in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ endif()
 option(USE_CPPCHECK "Looking for cppcheck program ..." ON)
 
 
+add_definitions(-D_LARGEFILE64_SOURCE)
 add_definitions(-D_FORTIFY_SOURCE=2)
 add_definitions(-DVERSION=\"${VERSION}\")
 add_definitions(-D${CMAKE_C_PLATFORM_ID})

--- a/clipboard.c
+++ b/clipboard.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <signal.h>

--- a/cmdline.c
+++ b/cmdline.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE     /* required for GLIBC to enable stat64 and friends */
 #include "doassert.h"
 #include <sys/types.h>
 #include <regex.h>

--- a/color.c
+++ b/color.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE     /* required for GLIBC to enable stat64 and friends */
 #include "doassert.h"
 #include <sys/types.h>
 #include <regex.h>

--- a/config.c
+++ b/config.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE     /* required for GLIBC to enable stat64 and friends */
 #include "doassert.h"
 #include <sys/types.h>
 #include <regex.h>

--- a/cv.c
+++ b/cv.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE     /* required for GLIBC to enable stat64 and friends */
 #include <sys/types.h>
 #include <regex.h>
 #include <stdlib.h>

--- a/diff.c
+++ b/diff.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE     /* required for GLIBC to enable stat64 and friends */
 #include <sys/types.h>
 #include <regex.h>
 #include <string.h>

--- a/error.c
+++ b/error.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE     /* required for GLIBC to enable stat64 and friends */
 #include <sys/types.h>
 #include <unistd.h>
 #include <errno.h>

--- a/exec.c
+++ b/exec.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE     /* required for GLIBC to enable stat64 and friends */
 #include <sys/types.h>
 #include <regex.h>
 #include <sys/stat.h>

--- a/globals.c
+++ b/globals.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE     /* required for GLIBC to enable stat64 and friends */
 #include <regex.h>
 #include <string.h>
 #include <time.h>

--- a/help.c
+++ b/help.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE	/* required for GLIBC to enable stat64 and friends */
 #include <ctype.h>
 #include <regex.h>
 #include <stdlib.h>

--- a/history.c
+++ b/history.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE
 #include <sys/types.h>
 #include <unistd.h>
 #include <stdio.h>

--- a/mem.c
+++ b/mem.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE	/* required for GLIBC to enable stat64 and friends */
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/misc.c
+++ b/misc.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE     /* required for GLIBC to enable stat64 and friends */
 #include <sys/types.h>
 #include <regex.h>
 #include <sys/utsname.h>

--- a/mt.c
+++ b/mt.c
@@ -1,5 +1,4 @@
 #define _GNU_SOURCE
-#define _LARGEFILE64_SOURCE	/* required for GLIBC to enable stat64 and friends */
 #include <ctype.h>
 #include <sys/types.h>
 #include <pwd.h>

--- a/mt.h
+++ b/mt.h
@@ -1,7 +1,6 @@
 #ifndef __MT_H__
 #define __MT_H__
 
-#define _LARGEFILE64_SOURCE	/* required for GLIBC to enable stat64 and friends */
 #include <regex.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/my_pty.c
+++ b/my_pty.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE     /* required for GLIBC to enable stat64 and friends */
 /* I read somewhere that this is needed on HP-UX */
 #define _INCLUDE_HPUX_SOURCE
 #define _INCLUDE_POSIX_SOURCE

--- a/scrollback.c
+++ b/scrollback.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE	/* required for GLIBC to enable stat64 and friends */
 #include <ctype.h>
 #include <sys/types.h>
 #include <regex.h>

--- a/selbox.c
+++ b/selbox.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE     /* required for GLIBC to enable stat64 and friends */
 #include <sys/types.h>
 #include <regex.h>
 #include <stdio.h>

--- a/stripstring.c
+++ b/stripstring.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE     /* required for GLIBC to enable stat64 and friends */
 #include <sys/types.h>
 #include <regex.h>
 #include <string.h>

--- a/term.c
+++ b/term.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE	/* required for GLIBC to enable stat64 and friends */
 #include <ctype.h>
 #include <errno.h>
 #include <sys/time.h>

--- a/ui.c
+++ b/ui.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE     /* required for GLIBC to enable stat64 and friends */
 #include <sys/types.h>
 #include <regex.h>
 #include <string.h>

--- a/utils.c
+++ b/utils.c
@@ -1,4 +1,3 @@
-#define _LARGEFILE64_SOURCE	/* required for GLIBC to enable stat64 and friends */
 #include "doassert.h"
 #include <errno.h>
 #include <signal.h>


### PR DESCRIPTION
Move the `_LARGEFILE64_SOURCE` macro definition from individual source files to CMakeLists.txt. This eliminates redefinition warnings when system headers (features.h) also define this macro:

~~~
In file included from
/builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/mt.c:50: /builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/mt.h:4:9: warning: ‘_LARGEFILE64_SOURCE’ redefined
    4 | #define _LARGEFILE64_SOURCE     /* required for GLIBC to enable
stat64 and friends */
      |         ^~~~~~~~~~~~~~~~~~~
In file included from /usr/include/ctype.h:25,
                 from
/builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/mt.c:3:
/usr/include/features.h:238:10: note: this is the location of the
previous definition
  238 | # define _LARGEFILE64_SOURCE    1
      |          ^~~~~~~~~~~~~~~~~~~
~~~