### PR TITLE
Handle asprintf failure in escape()

### DIFF
--- a/mt.c
+++ b/mt.c
@@ -767,7 +767,8 @@ char *escape(const char *what, const proginfo *const cur)
 
 		*p = 0x00;
 
-		asprintf(&new_str, "%s%s%s", temp, cur -> filename, p + 2);
+		if (asprintf(&new_str, "%s%s%s", temp, cur -> filename, p + 2) == -1)
+			error_exit(FALSE, FALSE, "Out of memory in escape()\n");
 
 		free(temp);
 


### PR DESCRIPTION
Exit with error on allocation failure using `error_exit()`.

Fixes the following warning:

~~~
/builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/mt.c: In function ‘escape’:
/builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/mt.c:770:17: warning: ignoring return value of ‘asprintf’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  770 |                 asprintf(&new_str, "%s%s%s", temp, cur ->
filename, p + 2);
      |
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~~~