### PR TITLE
Fix format-truncation and strncpy compiler warnings

### DIFF
--- a/mt.h
+++ b/mt.h
@@ -27,7 +27,7 @@
 #define SL_ATTR		(2)
 
 #define LOADAVG_STR_LEN		(20)
-#define AMOUNT_STR_LEN		(3 + 2 + 1)
+#define AMOUNT_STR_LEN		16
 
 #ifndef __GNUC__
         #define __PRETTY_FUNCTION__	"(unknown)"

--- a/ui.c
+++ b/ui.c
@@ -130,7 +130,7 @@ void edit_color(int index)
 		else if (c == 'r' || c == 'g' || c == 'b')
 		{
 			int y = -1;
-			char val_str[5] = { 0 };
+			char val_str[8] = { 0 };
 			int val = -1;
 			char *newval = NULL;
 
@@ -1162,8 +1162,7 @@ int edit_regexp(void)
 			if (toupper((cur -> pre)[loop].use_regex) == 'X')
 			{
 				char dummy[18];
-				strncpy(dummy, (cur -> pre)[loop].cmd, min(17, strlen((cur -> pre)[loop].cmd)));
-				dummy[17]=0x00;
+				snprintf(dummy, sizeof(dummy), "%s", (cur -> pre)[loop].cmd);
 				mvwprintw(mywin -> win, 4 + loop, 42, "%s", dummy);
 				wmove(mywin -> win, 4 + loop, 41);
 			}
@@ -2162,7 +2161,7 @@ int set_window_sizes(void)
 				if (window != -1)
 				{
 					char *str;
-					char oldval[5] = { 0 };
+					char oldval[12] = { 0 };
 
 					if (pi[window].win_height > -1)
 						snprintf(oldval, sizeof(oldval), "%d", pi[window].win_height);


### PR DESCRIPTION
Increased buffer sizes in `utils.c` and `ui.c` to accommodate the full range of integer values (preventing possible truncation).

Replaced `strncpy` with `snprintf` in `ui.c` to ensure destination buffers are always null-terminated and free of garbage data.

Fixes the following warning:

~~~
/builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/utils.c: In function ‘amount_to_str’: /builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/utils.c:371:52: warning: ‘__snprintf_chk’ output may be truncated before the last format character [-Wformat-truncation=]
  371 |                 snprintf(out, AMOUNT_STR_LEN, "%dKB", (int)((amount + M_KB - 1) / M_KB));
      |                                                    ^
In file included from /usr/include/stdio.h:974,
                 from /builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/utils.c:7:
In function ‘snprintf’,
    inlined from ‘amount_to_str’ at /builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/utils.c:371:3:
/usr/include/bits/stdio2.h:68:10: note: ‘__snprintf_chk’ output between 4 and 7 bytes into a destination of size 6
   68 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   69 |                                    __glibc_objsize (__s), __fmt,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   70 |                                    __va_arg_pack ());
      |                                    ~~~~~~~~~~~~~~~~~
/builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/utils.c: In function ‘amount_to_str’:
/builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/utils.c:369:52: warning: ‘__snprintf_chk’ output may be truncated before the last format character [-Wformat-truncation=]
  369 |                 snprintf(out, AMOUNT_STR_LEN, "%dMB", (int)((amount + M_MB - 1) / M_MB));
      |                                                    ^
In function ‘snprintf’,
    inlined from ‘amount_to_str’ at /builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/utils.c:369:3:
/usr/include/bits/stdio2.h:68:10: note: ‘__snprintf_chk’ output between 4 and 7 bytes into a destination of size 6
   68 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   69 |                                    __glibc_objsize (__s), __fmt,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   70 |                                    __va_arg_pack ());
      |                                    ~~~~~~~~~~~~~~~~~
/builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/ui.c: In function ‘edit_color’:
/builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/ui.c:155:69: warning: ‘%d’ directive output may be truncated writing between 1 and 6 bytes into a region of size 5 [-Wformat-truncation=]
  155 |                                 snprintf(val_str, sizeof(val_str), "%d", val);
      |                                                                     ^~
/builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/ui.c:155:68: note: directive argument in the range [-32768, 32767]
  155 |                                 snprintf(val_str, sizeof(val_str), "%d", val);
      |                                                                    ^~~~
In file included from /usr/include/stdio.h:974,
                 from /builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/ui.c:5:
In function ‘snprintf’,
    inlined from ‘edit_color’ at /builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/ui.c:155:5:
/usr/include/bits/stdio2.h:68:10: note: ‘__snprintf_chk’ output between 2 and 7 bytes into a destination of size 5
   68 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   69 |                                    __glibc_objsize (__s), __fmt,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   70 |                                    __va_arg_pack ());
      |                                    ~~~~~~~~~~~~~~~~~
/builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/ui.c: In function ‘set_window_sizes’:
/builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/ui.c:2168:83: warning: ‘%d’ directive output may be truncated writing between 1 and 10 bytes into a region of size 5 [-Wformat-truncation=]
 2168 |                                                 snprintf(oldval, sizeof(oldval), "%d", pi[window].win_height);
      |                                                                                   ^~
/builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/ui.c:2168:82: note: directive argument in the range [0, 2147483647]
 2168 |                                                 snprintf(oldval, sizeof(oldval), "%d", pi[window].win_height);
      |                                                                                  ^~~~
In function ‘snprintf’,
    inlined from ‘set_window_sizes’ at /builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/ui.c:2168:7:
/usr/include/bits/stdio2.h:68:10: note: ‘__snprintf_chk’ output between 2 and 11 bytes into a destination of size 5
   68 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   69 |                                    __glibc_objsize (__s), __fmt,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   70 |                                    __va_arg_pack ());
      |                                    ~~~~~~~~~~~~~~~~~
/builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/ui.c: In function ‘edit_regexp’:
/builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/ui.c:1165:33: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-truncation]
 1165 |                                 strncpy(dummy, (cur -> pre)[loop].cmd, min(17, strlen((cur -> pre)[loop].cmd)));
      |                                 ^
In file included from /builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/ui.c:24:
/builddir/build/BUILD/multitail-7.1.5-build/multitail-7.1.5/ui.c:1165:80: note: length computed here
 1165 |                                 strncpy(dummy, (cur -> pre)[loop].cmd, min(17, strlen((cur -> pre)[loop].cmd)));
~~~