### PR TITLE
regex: use PCRE POSIX headers on Cygwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ add_executable(multitail
     mem.h
     misc.h
     mt.h
+    mt_regex.h
     my_pty.h
     scrollback.h
     selbox.h

--- a/cmdline.c
+++ b/cmdline.c
@@ -1,6 +1,6 @@
 #include "doassert.h"
 #include <sys/types.h>
-#include <regex.h>
+#include "mt_regex.h"
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>

--- a/color.c
+++ b/color.c
@@ -1,6 +1,6 @@
 #include "doassert.h"
 #include <sys/types.h>
-#include <regex.h>
+#include "mt_regex.h"
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>

--- a/config.c
+++ b/config.c
@@ -1,6 +1,6 @@
 #include "doassert.h"
 #include <sys/types.h>
-#include <regex.h>
+#include "mt_regex.h"
 #include <string.h>
 #include <strings.h>
 #include <dirent.h>

--- a/cv.c
+++ b/cv.c
@@ -1,5 +1,5 @@
 #include <sys/types.h>
-#include <regex.h>
+#include "mt_regex.h"
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>

--- a/diff.c
+++ b/diff.c
@@ -1,5 +1,5 @@
 #include <sys/types.h>
-#include <regex.h>
+#include "mt_regex.h"
 #include <string.h>
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/error.c
+++ b/error.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>
-#include <regex.h>
+#include "mt_regex.h"
 #if defined(__GLIBC__)
 #include <execinfo.h>
 #endif
@@ -61,4 +61,3 @@ void error_exit_(BOOL show_errno, BOOL show_st, char *file, const char *function
 
 	exit(EXIT_FAILURE);
 }
-

--- a/exec.c
+++ b/exec.c
@@ -1,5 +1,5 @@
 #include <sys/types.h>
-#include <regex.h>
+#include "mt_regex.h"
 #include <sys/stat.h>
 #include <unistd.h>
 #include <sys/wait.h>

--- a/globals.c
+++ b/globals.c
@@ -1,4 +1,4 @@
-#include <regex.h>
+#include "mt_regex.h"
 #include <string.h>
 #include <time.h>
 #include <unistd.h>

--- a/help.c
+++ b/help.c
@@ -1,5 +1,5 @@
 #include <ctype.h>
-#include <regex.h>
+#include "mt_regex.h"
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/history.c
+++ b/history.c
@@ -2,7 +2,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <time.h>
-#include <regex.h>
+#include "mt_regex.h"
 #include <string.h>
 #include <errno.h>
 #include <sys/socket.h>

--- a/mem.c
+++ b/mem.c
@@ -6,7 +6,7 @@
 #include <unistd.h>
 #include <signal.h>
 #include <stdarg.h>
-#include <regex.h>
+#include "mt_regex.h"
 #include <sys/socket.h>
 #include <netinet/in.h>
 

--- a/misc.c
+++ b/misc.c
@@ -1,5 +1,5 @@
 #include <sys/types.h>
-#include <regex.h>
+#include "mt_regex.h"
 #include <sys/utsname.h>
 #include <string.h>
 #include <math.h>

--- a/mt.c
+++ b/mt.c
@@ -6,7 +6,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
-#include <regex.h>
+#include "mt_regex.h"
 #if !defined(__APPLE__) && !defined(__CYGWIN__)
 #include <search.h>
 #endif

--- a/mt.c
+++ b/mt.c
@@ -2272,12 +2272,15 @@ void set_default_parameters_if_not_given_do(proginfo *cur, int pi_index)
 			}
 			/* we should inform the user of any errors while executing
 			 * the regexp! */
-			else
+			else if (rc != REG_NOMATCH)
 			{
 				char *error = convert_regexp_error(rc, &ppf[ppf_index].regex);
 
 				if (error)
-					error_popup("Set default parameters", -1, "Execution of regular expression failed with error:\n%s\n", error);
+				{
+					error_popup("Set default parameters", -1, "Execution of regular expression failed with error:\nRegular expression: %s\n%s\n", ppf[ppf_index].re_str, error);
+					myfree(error);
+				}
 			}
 		}
 

--- a/mt.h
+++ b/mt.h
@@ -1,7 +1,7 @@
 #ifndef __MT_H__
 #define __MT_H__
 
-#include <regex.h>
+#include "mt_regex.h"
 #include <stdint.h>
 #include <stdio.h>
 #include <arpa/inet.h>

--- a/mt_regex.h
+++ b/mt_regex.h
@@ -1,0 +1,10 @@
+#ifndef __MT_REGEX_H__
+#define __MT_REGEX_H__
+
+#if defined(__CYGWIN__)
+#include <pcreposix.h>
+#else
+#include <regex.h>
+#endif
+
+#endif

--- a/my_pty.c
+++ b/my_pty.c
@@ -10,7 +10,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <sys/types.h>
-#include <regex.h>
+#include "mt_regex.h"
 
 #include <sys/stat.h>
 #include <unistd.h>

--- a/scrollback.c
+++ b/scrollback.c
@@ -1,6 +1,6 @@
 #include <ctype.h>
 #include <sys/types.h>
-#include <regex.h>
+#include "mt_regex.h"
 #include <string.h>
 #include <stdlib.h>
 #include <pwd.h>

--- a/selbox.c
+++ b/selbox.c
@@ -1,5 +1,5 @@
 #include <sys/types.h>
-#include <regex.h>
+#include "mt_regex.h"
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/stripstring.c
+++ b/stripstring.c
@@ -1,5 +1,5 @@
 #include <sys/types.h>
-#include <regex.h>
+#include "mt_regex.h"
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>

--- a/term.c
+++ b/term.c
@@ -2,7 +2,7 @@
 #include <errno.h>
 #include <sys/time.h>
 #include <sys/types.h>
-#include <regex.h>
+#include "mt_regex.h"
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>

--- a/ui.c
+++ b/ui.c
@@ -1,5 +1,5 @@
 #include <sys/types.h>
-#include <regex.h>
+#include "mt_regex.h"
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/utils.c
+++ b/utils.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
-#include <regex.h>
+#include "mt_regex.h"
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <time.h>


### PR DESCRIPTION
Keep regex_t, regcomp/regexec, and REG_NOMATCH constants from the same implementation when linking against libpcreposix on Cygwin.

The issue seems to be introduced in c0ae091


Fix #69 