### PR TITLE
Add optional --collapse-cr for tqdm / HuggingFace Trainer logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ On Cygwin, you need the libpcre-devel package.
 
 Tips
 ----
+Following Python tqdm / HuggingFace Trainer logs that use carriage-return
+progress bars? Start MultiTail with `--collapse-cr` so lone `\r` overwrites
+are collapsed instead of forming multi-hundred-KB lines:
+
+    multitail --collapse-cr train.log
+
 You can also use MultiTail to view logfiles on other hosts!
 How?
 Like this:

--- a/cmdline.c
+++ b/cmdline.c
@@ -493,6 +493,8 @@ void do_commandline(int argc, char *argv[])
 	int mark_interval = 0;
 	char syslog_noreverse = 0;
 	char cont = 0;
+	char collapse_cr = 0;
+	char default_collapse_cr = 0;
 	char marker_of_other_window = 0;
 	char no_marker_of_other_window = 0;
 	char bufferwhat = -1;
@@ -555,6 +557,11 @@ void do_commandline(int argc, char *argv[])
 		else if (strcmp(argv[loop], "--cont") == 0)
 		{
 			cont = 1;
+		}
+		else if (strcmp(argv[loop], "--collapse-cr") == 0)
+		{
+			collapse_cr = 1;
+			default_collapse_cr = 1;
 		}
 		else if (strcmp(argv[loop], "--mark-interval") ==0)
 		{
@@ -1020,6 +1027,9 @@ void do_commandline(int argc, char *argv[])
 
 			cur -> cont = cont;
 			cont = 0;
+
+			cur -> collapse_cr = collapse_cr;
+			collapse_cr = default_collapse_cr;
 
 			/* 'watch' functionality configuration (more or less) */
 			cur -> restart.restart = restart;

--- a/help.c
+++ b/help.c
@@ -1434,7 +1434,8 @@ void usage(void)
 	format_help("-p x [y]", NULL, "set linewrap (l=left/a=all/r=right/s=syslog,S=syslog w/o procname,o=offset -> 'y',w=wordwrap)");
 	format_help("-P", NULL, "like -p but for all following files");
 	format_help("-b n", NULL, "set TAB-width");
-	format_help(NULL, "--cont", "reconnect lines with a '\' at the end");
+	format_help(NULL, "--cont", "reconnect lines with a '\\' at the end");
+	format_help(NULL, "--collapse-cr", "treat lone CR as TTY overwrite (tqdm / HF Trainer logs)");
 	fprintf(stderr, "\n");
 
 	help_header("line prefixes");

--- a/mt.c
+++ b/mt.c
@@ -3221,6 +3221,43 @@ int process_global_keys(int what_help, NEWWIN *popup, char cursor_shift)
 	return c;
 }
 
+/* Collapse lone CR overwrite sequences (tqdm / HuggingFace Trainer).
+ * A lone '\r' discards the current incomplete line fragment (TTY semantics).
+ * CRLF ("\r\n") is left as a normal line ending (CR dropped, LF kept).
+ * Default off — call only when cur->collapse_cr is set.
+ */
+static void collapse_cr_overwrite(char *buf)
+{
+	char *src = buf;
+	char *dst = buf;
+	char *line_start = buf;
+
+	while (*src)
+	{
+		if (*src == '\r')
+		{
+			if (src[1] == '\n')
+			{
+				/* Windows CRLF: drop CR, keep LF via the normal path */
+				src++;
+				continue;
+			}
+			/* lone CR: discard current fragment, rewrite from line start */
+			dst = line_start;
+			src++;
+			continue;
+		}
+		if (*src == '\n')
+		{
+			*dst++ = *src++;
+			line_start = dst;
+			continue;
+		}
+		*dst++ = *src++;
+	}
+	*dst = 0x00;
+}
+
 char process_input_data(int win_nr, proginfo *cur, char *data_in, int new_data_offset, int n_bytes_added, double now)
 {
 	char *pnt = data_in;
@@ -3231,7 +3268,13 @@ char process_input_data(int win_nr, proginfo *cur, char *data_in, int new_data_o
 
 	data_in[new_data_offset + n_bytes_added] = 0x00;
 
-	if (strchr(&data_in[new_data_offset], '\n'))
+	if (cur -> collapse_cr)
+		collapse_cr_overwrite(data_in);
+
+	/* After collapse_cr, offsets into data_in may no longer match new_data_offset;
+	 * scan the whole buffer for newlines in that case.
+	 */
+	if (strchr(cur -> collapse_cr ? data_in : &data_in[new_data_offset], '\n'))
 	{
 		if (cur -> cont) /* reconnect lines with '\' */
 		{

--- a/mt.h
+++ b/mt.h
@@ -306,6 +306,8 @@ typedef struct _subwindow_
 
 	char cont;		/* "re-connect" lines with \ at the end */
 
+	char collapse_cr;	/* treat lone \r as TTY overwrite (tqdm / HF logs) */
+
 	char add_timestamp;
 
 	char *label;		/* put in front of each line */

--- a/multitail.1
+++ b/multitail.1
@@ -271,6 +271,9 @@ Proces a configurationfile item via the commandline in case you cannot edit the 
 .B "\--cont"
 Reconnect lines with a '\' at the end.
 .TP
+.B "\--collapse-cr"
+Treat a lone carriage return (CR) as a TTY-style overwrite: discard the current incomplete line fragment and keep only the text after the last CR. Useful for following Python tqdm / HuggingFace Trainer logs that rewrite progress bars with CR instead of LF. Windows CRLF line endings are preserved as normal newlines. Default is off.
+.TP
 .B "\--mark-interval interval"
 When nothing comes in, print a '---mark---' line every 'interval' seconds.
 .TP

--- a/ui.c
+++ b/ui.c
@@ -1598,6 +1598,9 @@ void write_script(void)
 				if (cur -> cont)
 					fprintf(fh, " --cont");
 
+				if (cur -> collapse_cr)
+					fprintf(fh, " --collapse-cr");
+
 				/* terminal emulation */
 				if (cur -> cdef.term_emul == TERM_ANSI)
 					fprintf(fh, " -cT ANSI"); /* vt100 */


### PR DESCRIPTION
### Summary

Fixes #71.

Tools like Python `tqdm` and HuggingFace Trainer write progress updates separated by `\r` (TTY overwrite) into redirected log files. MultiTail only splits on `\n`, so each window can accumulate a multi-hundred-KB “line” and wrap into an unreadable mess when following training logs.

This PR adds an **opt-in** `--collapse-cr` mode (default **off**) that treats a lone CR as a TTY-style overwrite: discard the current incomplete line fragment and keep only the text after the last CR. Real metrics lines that end with `\n` are unchanged. Windows `CRLF` is preserved as a normal newline (CR dropped, LF kept).

### Behavior

| Input fragment | With `--collapse-cr` |
|----------------|----------------------|
| `\r 1%\r 2%\r 79%\n{'loss': 1.23}\n` | `  79%\n{'loss': 1.23}\n` |
| `hello\r\nworld\r\n` | `hello\nworld\n` |
| normal syslog (`\n` only) | unchanged |

Usage:

```bash
multitail --collapse-cr train1.log train2.log
```

### What changed

| File | Change |
|------|--------|
| `mt.h` / `mt.c` | `collapse_cr` flag on `proginfo`; `collapse_cr_overwrite()` in `process_input_data` |
| `cmdline.c` | `--collapse-cr` (sticky for following windows) |
| `ui.c` | Persist `--collapse-cr` when dumping window config |
| `help.c` / `multitail.1` / `README.md` | Document the flag |

### Local verification

Constructed the fixture from the analysis:

```bash
python3 - <<'PY'
open('/tmp/tqdmish.log','w').write(
  ''.join(f'\r  {i}%|{"█"*(i//10)}| {i}/100' for i in range(1,80))
  + "\n{'loss': 1.23}\n"
)
PY
```

Without collapse, a `\n`-only split yields a **~2007-byte** “line” (79 CRs). After `collapse_cr_overwrite`, the buffer is:

```text
  79%|███████| 79/100
{'loss': 1.23}
```

(~51 bytes, 0 leftover CRs). Also checked: CRLF → LF; plain `\n` syslog unchanged.

Built on macOS (`makefile.macosx` + system `-lncurses`); `./multitail -h` lists `--collapse-cr`.

### Notes

- Default remains off so existing syslog / binary-adjacent text is unaffected.
- Existing strip/convert schemes still run on already-split lines; they cannot fix unbounded `incomplete_line` growth without a read-path change like this.
