### PR TITLE
collapse-cr: preserve trailing CR across reads

### DIFF
--- a/mt.c
+++ b/mt.c
@@ -3239,6 +3239,12 @@ static void collapse_cr_overwrite(char *buf)
 	{
 		if (*src == '\r')
 		{
+			if (src[1] == 0x00)
+			{
+				/* Need the next read to know whether this is CRLF or overwrite. */
+				*dst++ = *src++;
+				continue;
+			}
 			if (src[1] == '\n')
 			{
 				/* Windows CRLF: drop CR, keep LF via the normal path */


### PR DESCRIPTION
When --collapse-cr sees a buffer ending in '\r', keep it as part of the incomplete line instead of immediately treating it as a TTY overwrite. This lets the next read distinguish split CRLF input from a real lone-CR overwrite.

Without this, CRLF logs could be corrupted when a read boundary landed between '\r' and '\n', despite the option documenting CRLF as normal newline input.